### PR TITLE
Fix for #24

### DIFF
--- a/radlab-launcher/cloudsdk_kubectl_installer.py
+++ b/radlab-launcher/cloudsdk_kubectl_installer.py
@@ -27,10 +27,11 @@ def main():
   node = platform.node().lower()
 
   if('linux' in system and 'cs-' in node):
-    print("Detected Cloud Shell, skipping cloud sdk installation...")
+    print("Detected Cloud Shell, skipping cloud sdk & kubectl installation...")
   else:
     os.system("curl https://sdk.cloud.google.com > install.sh")
     os.system("bash install.sh --disable-prompts")
+    os.system("sudo gcloud components install kubectl")
 
 
 if __name__ == "__main__":

--- a/radlab-launcher/installer_prereq.py
+++ b/radlab-launcher/installer_prereq.py
@@ -21,8 +21,7 @@ def main():
     # Install production dependencies.
     os.system("pip3 install --no-cache-dir -r requirements.txt")
     os.system("python3 terraform_installer.py")
-    os.system("python3 cloud_sdk_installer.py")
-    os.system("sudo gcloud components install kubectl")
+    os.system("python3 cloudsdk_kubectl_installer.py")
     print("\nPRE-REQ INSTALLTION COMPLETED\n")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Thank you for raising the issue. 

It is correct that **kubectl** comes pre-installed in Cloud Shell thus the manual installation is not required. Thus you can continue with triggering the RAD Lab Launcher by running **radlab.py** to deploy modules.

Meanwhile we are introducing this quick fix to skip the 'kubectl' installation only when the deployment runs on Cloud Shell.