### PR TITLE
RADLab Launcher Enhancement + BugFix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,16 @@ Here we write upgrading notes for RAD Lab repo. It's a team effort to make them 
  
 ### Fixed
 
-## [6.0.0]() (2022-04-19)
+## [6.1.1](https://github.com/GoogleCloudPlatform/rad-lab/releases/tag/v6.1.1) (2022-04-26)
+
+[Full Changelog](https://github.com/GoogleCloudPlatform/rad-lab/compare/v6.0.0...v6.1.1)
+
+### Added
+ - _RAD Lab Launcher:_ Listing Existing Deployments when Updating/Deleting any deployment.[(#55)](https://github.com/GoogleCloudPlatform/rad-lab/pull/55)
+### Fixed
+- _RAD Lab Launcher:_ Fix for empty line in the file of "--varfile" used to cause error of "index out of range" and fail the execution of "python3 radlab.py --module.... --varfile ./xxxxx". [(#55)](https://github.com/GoogleCloudPlatform/rad-lab/pull/55)
+
+## [6.0.0](https://github.com/GoogleCloudPlatform/rad-lab/releases/tag/v6.0.0) (2022-04-19)
 
 [Full Changelog](https://github.com/GoogleCloudPlatform/rad-lab/compare/v5.1.1...v6.0.0)
 ### Added

--- a/radlab-launcher/radlab.py
+++ b/radlab-launcher/radlab.py
@@ -790,7 +790,7 @@ def list_radlab_deployments(tfbucket, module_name, projid):
     bucket = storage_client.get_bucket(tfbucket)
     iterator = bucket.list_blobs(prefix='radlab/',delimiter='/')
     response = iterator._get_next_page_response()
-    print("\nPlease find the list of "+ module_name + " module below:\n")
+    print("\nPlease find the list of existing "+ module_name + " module deployments below:\n")
 
     for prefix in response['prefixes']:
         if module_name in prefix:
@@ -871,8 +871,11 @@ def module_deploy_common_settings(action,module_name,setup_path,varcontents,proj
 
     elif(action == ACTION_UPDATE_DEPLOYMENT or action == ACTION_DELETE_DEPLOYMENT):
         
+        # List Existing Deployments
+        list_radlab_deployments(tfbucket, module_name, projid)
+
         # Get Deployment ID
-        randomid = input(Fore.YELLOW + Style.BRIGHT + "\nEnter RAD Lab Module Deployment ID (example 'l8b3' is the id for project with id - radlab-ds-analytics-l8b3)" + Style.RESET_ALL + ': ')
+        randomid = input(Fore.YELLOW + Style.BRIGHT + "\nEnter RAD Lab Module Deployment ID (example 'l8b3' is the id for module deployment with name - data_science_l8b3)" + Style.RESET_ALL + ': ')
         randomid = randomid.strip()
 
         # Validating Deployment ID
@@ -976,7 +979,7 @@ def fetchvariables(filecontents):
         # Skipping for commented lines
         if x.startswith('#') or x.startswith('//'):
             continue
-        else:
+        elif (len(x.split("=")) == 2):
             x = x.strip()
             # print(x)
             variables[x.split("=")[0].strip()] = x.split("=")[1].strip()


### PR DESCRIPTION
- Listing Existing Deployments when Updating/Deleting any deployment.
- Fixing a bug in Launcher. An empty line in the file of "--varfile" will cause error of "index out of range" and fail the execution of "python3 radlab.py --module.... --varfile ./xxxxx"