### PR TITLE
Adding RAD Lab Service Catalog Tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,97 @@
+# Supporting Tools
+
+This document explains the different types of supporting tools included in this repo which you can utilize for building & supporting RAD Lab modules.
+
+:green_circle: _These tools are built on Python and supported for `Python 3.7.3` & above._
+
+### OS Support:
+- Mac
+- Windows
+- Linux
+
+## 1. Terraform Module Doc Builder
+
+### WHAT?
+
+This tool builds the variables & outputs of a terraform module and add it to the README.md of the module.
+
+### HOW?
+
+#### STEP 1
+
+Add below 2 tags in the Argolis Common Problems TF solution specific README.md for populating structured Variables and Outputs automatically via [tfdoc.py](tfdoc.py).
+
+```
+<!-- BEGIN TFDOC -->
+<!-- END TFDOC -->
+```
+
+#### STEP 2
+```python3 tfdoc.py <path/to/tf/module>```
+
+Example:
+
+```python3 tfdoc.py ./../common-problems-solutions/tf_solution_1```
+
+## 2. License Boilderplate
+
+### WHAT?
+
+This tool returns the list of files (with complete file paths) which are missing Apache 2.0 Lisence.
+
+:green_circle: _The checks are done on *Dockerfile* , *.py*, *.sh*, *.tf*,
+*.yaml*, *.yml* file types._
+
+### HOW?
+
+```python3 check_boilerplate.py <path/to/folder>```
+
+## 3. RADLab Service Catalog Solution Builder
+
+### WHAT?
+
+This tool converts respective RAD Lab module into the zipped file which can be used as the [Terraform config solution](https://cloud.google.com/service-catalog/docs/terraform-configuration#create_module) for Service Catalog.
+
+:green_circle: _Follow Service Catalog quickstart [guide](https://cloud.google.com/service-catalog/docs/quickstart) to Setup a catalog & RadLab Solutions within the catalog._
+
+### HOW?
+
+```python3 service-catalog.py```
+
+#### Example Run
+
+```
+% python3 service-catalog.py
+
+List of available RAD Lab modules:
+[1] # RAD Lab alpha fold module (alpha_fold)
+[2] # RAD Lab Application Mordernization Module (w/ Elasticsearch) (app_mod_elastic)
+[3] # RAD Lab Data Science Module (data_science)
+[4] # RAD Lab Genomics-Cromwell Module (genomics_cromwell)
+[5] # RAD Lab Genomics Module (genomics_dsub)
+[6] # RAD Lab Silicon Design Module (silicon_design)
+[7] Exit
+Choose a number for the RAD Lab Module: 1
+
+RAD Lab Module (selected) : alpha_fold
+  adding: main.tf (deflated 69%)
+  adding: orgpolicy.tf (deflated 64%)
+  adding: outputs.tf (deflated 46%)
+  adding: scripts/ (stored 0%)
+  adding: scripts/.DS_Store (deflated 96%)
+  adding: scripts/usage/ (stored 0%)
+  adding: scripts/build/ (stored 0%)
+  adding: scripts/build/startup_script.sh (deflated 53%)
+  adding: variables.tf (deflated 70%)
+  adding: versions.tf (deflated 40%)
+Please find the zipped solution here: /<path_to_repo_tools>/rad-lab/tools/radlab-service-catalog/alpha_fold.zip
+```
+
+## 4. GitHub Actions Scripts
+
+Below 4 scripts are used in the respective GitHub actions:
+
+- [BUILD - Module README](../.github/workflows/build-module-readme.yml) :  Uses [build_readme.py](build_readme.py) & [tfdoc.py](tfdoc.py) for a specific Pull Request and make sure that details of the Variables and Outputs of a module is documented in respective module README.
+- [CHECK - License Boilerplate](../.github/workflows/check-license.yml) :  Uses [check_documentation.py](check_documentation.py) & [check_boilerplate.py](check_boilerplate.py) for a specific Pull Request and make sure that Apache 2.0 License header are added to the files.
+- [CHECK - Terraform Plan](../.github/workflows/check-tf-plan.yml) :  Uses [check-tf-plan.py](check-tf-plan.py) for a specific Pull Request and run the `terraform init` and `terraform plan` unit testing for any RADLab module addition/modification.
+- [BUILD - RAD Lab Notifications](../.github/workflows/notifications.yml) : Uses [notications.py](notifications.py) to send out notifications to the Repo Admins/Maintainers for any new pull or issue request.

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,3 +3,4 @@ python-dateutil
 pytz
 requests
 python-terraform>=0.10.1
+colorama>=0.4.4

--- a/tools/service-catalog.py
+++ b/tools/service-catalog.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+
+# Copyright 2022 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import sys
+import glob
+import shutil
+from colorama import Fore, Back, Style
+
+def main():
+
+    # List existing RADLab Modules
+    module = list_modules()
+    
+    sc_path = os.getcwd() + '/radlab-service-catalog'
+
+    # Creating RadLab Service Catalog Package folder
+    os.system('mkdir -p ' + sc_path)
+
+    # Pull specific folder from RADLab GitHub Repo
+    shutil.copytree(os.path.dirname(os.getcwd()) + '/modules/'+ module, sc_path + '/' + module)
+
+    for filename in os.listdir(sc_path + '/' + module):
+
+        f = os.path.join(sc_path + '/' + module, filename)
+
+        # Remove all non.tf files from the root of the module
+        if os.path.isfile(f) and os.path.splitext(f)[1] != ".tf":
+            os.remove(f)
+
+    # Zip the module in such a way that .tf files are at the root of the zipped file
+    os.system('cd ' + sc_path + '/' + module + '; zip -r ' + module + '.zip *')
+
+    # Move thezip package to the RADLab Service Catalog Folder
+    os.system('mv ' + sc_path + '/' + module + '/' + module + '.zip ' + sc_path )
+
+    # Remove the downloaded module
+    os.system('rm -r ' + sc_path + '/' + module)
+
+    # Printing path to RADLab's Service Catalog Solution.
+    print("Please find the zipped solution here: " + sc_path + '/' + module +'.zip')
+
+def list_modules():
+    modules = [s.replace(os.path.dirname(os.getcwd()) + '/modules/', "") for s in glob.glob(os.path.dirname(os.getcwd()) + '/modules/*')]
+    modules = sorted(modules)
+    c = 1
+    print_list = ''
+
+    # Printing List of Modules
+    for module in modules:
+        first_line = ''
+        # Fetch Module name
+        try:
+            with open(os.path.dirname(os.getcwd()) + '/modules/'+ module + '/README.md', "r") as file:
+                first_line = file.readline()
+        except:
+            print(Fore.RED +'Missing README.md file for module: ' + module + Style.RESET_ALL)
+        print_list = print_list + "["+ str(c) +"] " + first_line.strip() + Fore.GREEN + " (" +module + ")\n" + Style.RESET_ALL
+        c = c+1
+
+    # Selecting Module
+    try:
+        selected_module = input("\nList of available RAD Lab modules:\n"+print_list+"["+ str(c) +"] Exit\n"+ Fore.YELLOW + Style.BRIGHT + "Choose a number for the RAD Lab Module"+ Style.RESET_ALL + ': ').strip()
+        selected_module = int(selected_module)
+    except:
+        sys.exit(Fore.RED + "\nInvalid module")
+
+    # Validating User Module selection
+    if selected_module > 0 and selected_module < c:
+        # print(modules)
+        module_name = modules[selected_module-1]
+        print("\nRAD Lab Module (selected) : "+ Fore.GREEN + Style.BRIGHT +module_name+ Style.RESET_ALL)
+        return module_name
+    elif selected_module == c:
+        sys.exit(Fore.GREEN + "\nExiting Installer")
+    else:
+        sys.exit(Fore.RED + "\nInvalid module")
+
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This tool generates zip files for respective RAD Lab module which can be used as the [Terraform config solution](https://cloud.google.com/service-catalog/docs/terraform-configuration#create_module) for GCP Service Catalog.