### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/deploy-radlab-ui.yml
+++ b/.github/workflows/deploy-radlab-ui.yml
@@ -49,12 +49,12 @@ jobs:
         run: |
           if [[ "${{ github.event.inputs.BRname }}" == "staging" || "${{ github.event.ref }}" == *"staging"* ]]
           then
-            echo "::set-output name=branch::staging"
+            echo "branch=staging" >> "$GITHUB_OUTPUT"
             echo "${{ secrets.STAGING_APP_YAML }}" > app.yaml
             echo "${{ secrets.STAGING_ENV }}" > .env.production.local
           elif [[ "${{ github.event.inputs.BRname }}" == "main" || "${{ github.event.ref }}" == *"main"* ]]
           then
-            echo "::set-output name=branch::main"
+            echo "branch=main" >> "$GITHUB_OUTPUT"
             echo "${{ secrets.PROD_APP_YAML }}" > app.yaml
             echo "${{ secrets.PROD_ENV }}" > .env.production.local
           else


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter